### PR TITLE
[HACK20-17] Add steps to run via Buildkite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,6 +5,7 @@ steps:
     agents:
       type: aws-buildkite-agent
       environment: sandpit
+      region: us-east-1 
     env:
       AUTH_EMAIL: "test.automation+e2eapitests@safetyculture.io" # User is also used for s12-apis-tests
       AUTH_PASSWORD: "7c9wHCER/LpLkA=="

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,15 @@
+---
+steps:
+  - name: ":lighthouse: Running Frontend Performance Tests :lighthouse:" 
+    command: .buildkite/run-frontend-performance-tests.sh
+    agents:
+      type: aws-buildkite-agent
+      environment: sandpit
+    env:
+      AUTH_EMAIL: "test.automation+e2eapitests@safetyculture.io" # User is also used for s12-apis-tests
+      AUTH_PASSWORD: "7c9wHCER/LpLkA=="
+      LOGIN_URL: "https://sandpit-app.safetyculture.com/login.html"
+      TARGET_URL: "https://sandpit-app.safetyculture.com/dashboard"
+    artifact_paths:
+      - "*.html"
+      - "*.json"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,4 +12,3 @@ steps:
       TARGET_URL: "https://sandpit-app.safetyculture.com/dashboard"
     artifact_paths:
       - "*.html"
-      - "*.json"

--- a/.buildkite/run-frontend-performance-tests.sh
+++ b/.buildkite/run-frontend-performance-tests.sh
@@ -17,6 +17,8 @@ fi
 docker build -t "${docker_tag}" -f Dockerfile .
 
 trap 'docker rm ${docker_container_name}' EXIT
+
+echo "--- Executing tests against: ${TARGET_URL}"
 docker run --name "${docker_container_name}" \
     -e EMAIL \
     -e PASSWORD \

--- a/.buildkite/run-frontend-performance-tests.sh
+++ b/.buildkite/run-frontend-performance-tests.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+export EMAIL=${AUTH_EMAIL:?"AUTH_EMAIL env var must be set"}
+export PASSWORD=${AUTH_PASSWORD:?"AUTH_PASSWORD env var must be set"}
+export LOGIN_URL=${LOGIN_URL:?"LOGIN_URL env var must be set"}
+export TARGET_URL=${TARGET_URL:?"TARGET_URL env var must be set"}
+
+docker_container_name="frontend-performance-container"
+docker_tag="${docker_container_name}:latest"
+if [[ "${CI:=false}" == true ]]; then
+    docker_tag="${docker_container_name}:${BUILDKITE_BUILD_NUMBER}"
+fi
+docker build -t "${docker_tag}" -f Dockerfile .
+
+trap 'docker rm ${docker_container_name}' EXIT
+docker run --name "${docker_container_name}" \
+    -e EMAIL \
+    -e PASSWORD \
+    -e LOGIN_URL \
+    -e TARGET_URL \
+    "${docker_tag}"
+
+docker cp "${docker_container_name}:/app/report.html" .


### PR DESCRIPTION
Example build can be found here: https://buildkite.com/safetyculture/frontend-performance-tests/builds/5

You can also run the script locally by executing:
```
export AUTH_EMAIL="<email>"
export AUTH_PASSWORD="<password>"
export LOGIN_URL="<login_url>"
export TARGET_URL="<target_url>"

bash .buildkite/run-frontend-performance-tests.sh
```