### PR TITLE
[HACK20-17] Add docker compose for postgres and grafana locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+grafana_data
 node_modules
 *.html

--- a/README.md
+++ b/README.md
@@ -76,6 +76,36 @@ docker cp  lighthouse-container:/app/report.html .
 docker rm lighthouse-container
 ```
 
+## Running Docker Compose with Postgres and Grafana
+First time setup to setup grafana with postgres source
+```
+# Bring up postgres and grafana locally
+docker-compose up
+
+# You can not interact with postgres directly on `localhost:5432`
+# Credentials: lighthouse/lighthouse
+# Database: lighthouse
+
+# Login to Grafana and configure postgres datasource
+Go to http://localhost:3000
+USERNAME=admin
+PASSWORD=pass
+
+Go to http://localhost:3000/datasources
+1. Add data source
+2. Search for PostgreSQL
+3. Configure data source:
+    - Name: Lighthouse PostgreSQL
+    - Host: postgres:5432
+    - Database: lighthouse
+    - User: lighthouse
+    - Password: lighthouse
+    - SSL Mode: disable
+    - PostgreSQL Details Version: 12
+
+# You can now configure new dashboard panels by selecting the "Lighthouse PostgreSQL" as the datasource
+```
+
 ## Enhancements to make
 
 * Use of budgets (TODO)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: "3"
+services:
+  postgres:
+    image: "postgres:12.2"
+    container_name: "frontend-performance-tests_postgres"
+    environment:
+      - POSTGRES_USER=lighthouse
+      - POSTGRES_PASSWORD=lighthouse
+      - POSTGRES_DB=lighthouse
+    ports:
+      - "5432:5432"
+
+  grafana:
+    image: grafana/grafana:latest
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=pass
+    ports:
+      - "3000:3000"
+    volumes:
+      - "./grafana_data:/var/lib/grafana"
+    depends_on:
+      - postgres


### PR DESCRIPTION
This allows you to run both postgres and grafana containers locally. Details on how to access each of them in the readme.